### PR TITLE
SAR-9765 Enable numeric key pad for CRN and Utr entry on mobile devices

### DIFF
--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_company_number_page.scala.html
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_company_number_page.scala.html
@@ -58,7 +58,9 @@
             isPageHeading = false,
             label = messages("capture-company-number.heading"),
             hint = Some(Html(s"""<p class="govuk-body iei_hint">${messages("capture-company-number.hint")}</p>""")),
-            classes = "govuk-input--width-10"
+            classes = "govuk-input--width-10",
+            inputMode = Some("numeric"),
+            pattern = Some("[0-9]*")
         )
 
         @govukButton(Button(

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_ctutr_page.scala.html
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_ctutr_page.scala.html
@@ -43,7 +43,9 @@
             label = messages("capture-ctutr.heading"),
             isPageHeading = true,
             hint = Some(Html(s"""<p class="govuk-body">${messages("capture-ctutr.line")}</p>""")),
-            classes = "govuk-input--width-20"
+            classes = "govuk-input--width-20",
+            inputMode = Some("numeric"),
+            pattern = Some("[0-9]*")
         )
 
         <div class="govuk-body">

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_optional_ctutr_page.scala.html
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/capture_optional_ctutr_page.scala.html
@@ -45,7 +45,9 @@
             label = messages("capture-ctutr.registered_society_heading"),
             isPageHeading = true,
             hint = Some(Html(s"""<p class="govuk-body">${messages("capture-ctutr.line")}</p>""")),
-            classes = "govuk-input--width-20"
+            classes = "govuk-input--width-20",
+            inputMode = Some("numeric"),
+            pattern = Some("[0-9]*")
         )
 
         @govukDetails(Details(

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/helpers/inputText.scala.html
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/helpers/inputText.scala.html
@@ -30,7 +30,9 @@
         classes: String = "",
         stripWhitespace: Boolean = false,
         autocomplete: Option[String] = None,
-        inputType: String = "text"
+        inputType: String = "text",
+        inputMode: Option[String] = None,
+        pattern: Option[String] = None
 )(implicit messages: Messages)
 
 @govukInput(
@@ -50,6 +52,8 @@
         value = form(name).value,
         autocomplete = autocomplete.map(value => value),
         inputType = inputType,
-        classes = classes
+        classes = classes,
+        inputmode = inputMode,
+        pattern = pattern
     ).withFormField(form(name))
 )

--- a/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/CaptureCompanyNumberTests.scala
+++ b/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/CaptureCompanyNumberTests.scala
@@ -79,6 +79,16 @@ trait CaptureCompanyNumberTests {
       doc.getHintText mustBe messages.hint
     }
 
+    "have an input text field marked as numeric" in {
+      val textInputs: Elements = doc.getTextFieldInput("companyNumber")
+
+      textInputs.size() mustBe 1
+
+      textInputs.first.attr("type") mustBe "text"
+      textInputs.first.attr("inputmode") mustBe "numeric"
+      textInputs.first.attr("pattern") mustBe "[0-9]*"
+    }
+
     "have a save and confirm button" in {
       doc.getSubmitButton.first.text mustBe Base.saveAndContinue
     }

--- a/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/CaptureCtutrViewTests.scala
+++ b/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/CaptureCtutrViewTests.scala
@@ -80,6 +80,15 @@ trait CaptureCtutrViewTests {
       doc.getParagraphs.eq(1).text mustBe messages.line
     }
 
+    "have an input text field marked as numeric" in {
+      val textInputs: Elements = doc.getTextFieldInput("ctutr")
+      textInputs.size() mustBe 1
+
+      textInputs.first.attr("type") mustBe "text"
+      textInputs.first.attr("inputmode") mustBe "numeric"
+      textInputs.first.attr("pattern") mustBe "[0-9]*"
+    }
+
     "have a correct link" in {
       doc.getLink("lost-utr").text mustBe messages.lostUtr
     }
@@ -148,6 +157,15 @@ trait CaptureCtutrViewTests {
 
     "have the correct first line" in {
       doc.getParagraphs.eq(1).text mustBe messages.line
+    }
+
+    "have an input text field marked as numeric" in {
+      val textInputs: Elements = doc.getTextFieldInput("ctutr")
+      textInputs.size() mustBe 1
+
+      textInputs.first.attr("type") mustBe "text"
+      textInputs.first.attr("inputmode") mustBe "numeric"
+      textInputs.first.attr("pattern") mustBe "[0-9]*"
     }
 
     "have the correct details summary" in {


### PR DESCRIPTION
Update of inputText component to enable HTML attributes "inputmode" and "pattern" to be defined. Then update CRN and Ct Utr input fields setting input mode to "numeric" and pattern to "[0-9]*".