### PR TITLE
Use absolute path for BV redirect when running locally

### DIFF
--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/config/AppConfig.scala
@@ -100,4 +100,6 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   lazy val timeout: Int = servicesConfig.getInt("timeout.timeout")
   lazy val countdown: Int = servicesConfig.getInt("timeout.countdown")
 
+  lazy val bvContinueResultBaseUrl: String = config.get[String]("urls.bvContinueResultBaseUrl")
+
 }

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/config/AppConfig.scala
@@ -100,6 +100,6 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, config: Configuration)
   lazy val timeout: Int = servicesConfig.getInt("timeout.timeout")
   lazy val countdown: Int = servicesConfig.getInt("timeout.countdown")
 
-  lazy val bvContinueResultBaseUrl: String = config.get[String]("urls.bvContinueResultBaseUrl")
+  lazy val bvResultBaseUrl: String = config.get[String]("urls.bvResultBaseUrl")
 
 }

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/connectors/CreateBusinessVerificationJourneyConnector.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/connectors/CreateBusinessVerificationJourneyConnector.scala
@@ -51,7 +51,7 @@ class CreateBusinessVerificationJourneyConnector @Inject()(http: HttpClient,
           Json.obj(
           "ctUtr" -> ctutr
         )),
-        "continueUrl" -> routes.BusinessVerificationController.retrieveBusinessVerificationResult(journeyId).url,
+        "continueUrl" -> s"${appConfig.bvContinueResultBaseUrl}/$journeyId/business-verification-result",
         "accessibilityStatementUrl" -> journeyConfig.pageConfig.accessibilityUrl,
         "deskproServiceName" -> journeyConfig.pageConfig.deskProServiceId,
         "pageTitle" -> pageTitle

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/connectors/CreateBusinessVerificationJourneyConnector.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/connectors/CreateBusinessVerificationJourneyConnector.scala
@@ -51,7 +51,7 @@ class CreateBusinessVerificationJourneyConnector @Inject()(http: HttpClient,
           Json.obj(
           "ctUtr" -> ctutr
         )),
-        "continueUrl" -> s"${appConfig.bvContinueResultBaseUrl}/$journeyId/business-verification-result",
+        "continueUrl" -> s"${appConfig.bvResultBaseUrl}/$journeyId/business-verification-result",
         "accessibilityStatementUrl" -> journeyConfig.pageConfig.accessibilityUrl,
         "deskproServiceName" -> journeyConfig.pageConfig.deskProServiceId,
         "pageTitle" -> pageTitle

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,7 +60,7 @@ play.filters.csp {
     child-src = "'self' https://www.googletagmanager.com"
     connect-src = "'self' https://www.google-analytics.com http://localhost:12345 https://stats.g.doubleclick.net"
     default-src = "'none'"
-    form-action = "localhost:9895 localhost:8503 localhost:9028 'self'"
+    form-action = "localhost:9895 localhost:8503 localhost:9028 localhost:6743 'self'"
     font-src = "'self' https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com"
     frame-ancestors = "'self'"
     img-src =  "'self' https://ssl.gstatic.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com"
@@ -194,6 +194,10 @@ feedback {
 timeout {
   timeout = 900
   countdown = 120
+}
+
+urls {
+  bvContinueResultBaseUrl = "http://localhost:9718/identify-your-incorporated-business"
 }
 
 play.i18n.langs = ["en", "cy"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -197,7 +197,7 @@ timeout {
 }
 
 urls {
-  bvContinueResultBaseUrl = "http://localhost:9718/identify-your-incorporated-business"
+  bvResultBaseUrl = "http://localhost:9718/identify-your-incorporated-business"
 }
 
 play.i18n.langs = ["en", "cy"]

--- a/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/assets/TestConstants.scala
+++ b/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/assets/TestConstants.scala
@@ -196,7 +196,7 @@ object TestConstants {
         "ctUtr" -> ctUtr
       )
     ),
-    "continueUrl" -> s"/identify-your-incorporated-business/$journeyId/business-verification-result",
+    "continueUrl" -> s"http://localhost:9718/identify-your-incorporated-business/$journeyId/business-verification-result",
     "accessibilityStatementUrl" -> "/accessibility",
     "deskproServiceName" -> "vrs",
     "pageTitle" -> "Entity Validation Service"

--- a/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/stubs/BusinessVerificationStub.scala
+++ b/it/uk/gov/hmrc/incorporatedentityidentificationfrontend/stubs/BusinessVerificationStub.scala
@@ -37,7 +37,7 @@ trait BusinessVerificationStub extends WireMockMethods {
           "ctUtr" -> ctutr
         )
       ),
-      "continueUrl" -> routes.BusinessVerificationController.retrieveBusinessVerificationResult(journeyId).url,
+      "continueUrl" -> s"http://localhost:9718${routes.BusinessVerificationController.retrieveBusinessVerificationResult(journeyId).url}",
       "accessibilityStatementUrl" -> journeyConfig.pageConfig.accessibilityUrl,
       "deskproServiceName" -> journeyConfig.pageConfig.deskProServiceId,
       "pageTitle" -> journeyConfig.pageConfig.optLabels.flatMap(_.optEnglishServiceName)
@@ -77,7 +77,7 @@ trait BusinessVerificationStub extends WireMockMethods {
           "ctUtr" -> ctutr
         )
       ),
-      "continueUrl" -> routes.BusinessVerificationController.retrieveBusinessVerificationResult(journeyId).url,
+      "continueUrl" -> s"http://localhost:9718${routes.BusinessVerificationController.retrieveBusinessVerificationResult(journeyId).url}",
       "accessibilityStatementUrl" -> journeyConfig.pageConfig.accessibilityUrl,
       "deskproServiceName" -> journeyConfig.pageConfig.deskProServiceId,
       "pageTitle" -> journeyConfig.pageConfig.optLabels.flatMap(_.optEnglishServiceName)


### PR DESCRIPTION
An issue observed when running through the GRS journey with BV enabled **locally** is that relative paths are used when redirecting, resulting in 'Page not found', which means we have to manually change the port to the correct one in the browser to continue the journey.

A couple of changes here fix that:

1. Currently when redirecting to BV, BV returns a relative path, [a separate PR in BV](https://github.com/hmrc/business-verification/pull/74) will make it return an absolute path, but **only locally** as per the application.conf, which fixes the port issue. Because of this, `localhost:6743` (BV frontend) needs adding to the form-action CSP directive, otherwise GRS can't redirect there.
2. When BV redirects back to GRS, again it is using a relative path provided by GRS when starting the BV journey, this changes that to provide an absolute path **only locally**, but will still provide a relative path in the environments as per https://github.com/hmrc/app-config-base/pull/7668