### PR TITLE
DDCYLS-8570 PPT:Previously entered information should persist when using Change links

### DIFF
--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/CaptureCompanyNumberController.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/CaptureCompanyNumberController.scala
@@ -34,6 +34,7 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class CaptureCompanyNumberController @Inject()(companyProfileService: CompanyProfileService,
+                                               storageService: StorageService,
                                                journeyService: JourneyService,
                                                mcc: MessagesControllerComponents,
                                                view: capture_company_number_page,
@@ -45,10 +46,16 @@ class CaptureCompanyNumberController @Inject()(companyProfileService: CompanyPro
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request: MessagesRequest[AnyContent] =>
       authorised().retrieve(internalId) {
         case Some(authInternalId) =>
-          journeyService.getJourneyConfig(journeyId, authInternalId).map {
-            journeyConfig =>
+          for {
+            journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+            storedCompanyProfile <- storageService.retrieveCompanyProfile(journeyId)
+          } yield {
               implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
-              Ok(view(journeyConfig.pageConfig, routes.CaptureCompanyNumberController.submit(journeyId), CaptureCompanyNumberForm.form))
+              val form = storedCompanyProfile match {
+                case Some(companyProfile) => CaptureCompanyNumberForm.form.fill(companyProfile.companyNumber)
+                case None                 => CaptureCompanyNumberForm.form
+              }
+              Ok(view(journeyConfig.pageConfig, routes.CaptureCompanyNumberController.submit(journeyId), form))
           }
         case None =>
           throw new InternalServerException("Internal ID could not be retrieved from Auth")

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/CaptureCtutrController.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/CaptureCtutrController.scala
@@ -46,15 +46,26 @@ class CaptureCtutrController @Inject()(mcc: MessagesControllerComponents,
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request: MessagesRequest[AnyContent] =>
       authorised().retrieve(internalId) {
         case Some(authInternalId) =>
-          journeyService.getJourneyConfig(journeyId, authInternalId).map {
-            journeyConfig =>
+          for {
+            journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+            storedCtutr <- storageService.retrieveCtutr(journeyId)
+          } yield {
               val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
               implicit val messages: Messages = remoteMessagesApi.preferred(request)
               journeyConfig.businessEntity match {
                 case LimitedCompany =>
-                  Ok(ctutr_view(journeyConfig.pageConfig, routes.CaptureCtutrController.submit(journeyId), CaptureCtutrForm.form(LimitedCompany)))
+                  Ok(ctutr_view(
+                    journeyConfig.pageConfig,
+                    routes.CaptureCtutrController.submit(journeyId),
+                    storedCtutr.fold(CaptureCtutrForm.form(LimitedCompany))(CaptureCtutrForm.form(LimitedCompany).fill)
+                  ))
                 case RegisteredSociety =>
-                  Ok(optional_ctutr_view(journeyId, journeyConfig.pageConfig, routes.CaptureCtutrController.submit(journeyId), CaptureCtutrForm.form(RegisteredSociety)))
+                  Ok(optional_ctutr_view(
+                    journeyId,
+                    journeyConfig.pageConfig,
+                    routes.CaptureCtutrController.submit(journeyId),
+                    storedCtutr.fold(CaptureCtutrForm.form(RegisteredSociety))(CaptureCtutrForm.form(RegisteredSociety).fill)
+                  ))
                 case invalidEntity =>
                   throw new InternalServerException(s"Invalid entity: $invalidEntity on CTUTR page")
               }

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/ConfirmBusinessNameController.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/ConfirmBusinessNameController.scala
@@ -52,12 +52,21 @@ class ConfirmBusinessNameController @Inject()(incorporatedEntityInformationRetri
           journeyService.getJourneyConfig(journeyId, authInternalId).flatMap {
             journeyConfig =>
               implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
-              incorporatedEntityInformationRetrievalService.retrieveCompanyProfile(journeyId).map {
+              for {
+                storedCompanyProfile <- incorporatedEntityInformationRetrievalService.retrieveCompanyProfile(journeyId)
+                storedAnswer <- incorporatedEntityInformationRetrievalService.retrieveConfirmBusinessName(journeyId)
+              } yield storedCompanyProfile match {
                 case Some(companiesHouseInformation) =>
-                  Ok(view(journeyConfig.pageConfig,
-                    ConfirmBusinessNameForm.form(messages),
+                  val form = storedAnswer.fold(ConfirmBusinessNameForm.form(messages))(
+                    ConfirmBusinessNameForm.form(messages).fill
+                  )
+                  Ok(view(
+                    journeyConfig.pageConfig,
+                    form,
                     routes.ConfirmBusinessNameController.submit(journeyId),
-                    companiesHouseInformation.companyName, journeyId))
+                    companiesHouseInformation.companyName,
+                    journeyId
+                  ))
                 case None =>
                   throw new InternalServerException("No company profile stored")
               }
@@ -88,7 +97,8 @@ class ConfirmBusinessNameController @Inject()(incorporatedEntityInformationRetri
               },
             {
               case ConfirmBusinessNameForm.yes =>
-                journeyConfig.businessEntity match {
+                incorporatedEntityInformationRetrievalService.storeConfirmBusinessName(journeyId, ConfirmBusinessNameForm.yes).flatMap { _ =>
+                  journeyConfig.businessEntity match {
                   case LimitedCompany | RegisteredSociety =>
                     ctEnrolmentService.checkCtEnrolment(journeyId, enrolments, journeyConfig).map {
                       case Enrolled =>
@@ -98,9 +108,12 @@ class ConfirmBusinessNameController @Inject()(incorporatedEntityInformationRetri
                     }
                   case CharitableIncorporatedOrganisation =>
                     Future.successful(Redirect(routes.CaptureCHRNController.show(journeyId)))
+                  }
                 }
               case ConfirmBusinessNameForm.no =>
-                Future.successful(Redirect(routes.CaptureCompanyNumberController.show(journeyId)))
+                incorporatedEntityInformationRetrievalService.storeConfirmBusinessName(journeyId, ConfirmBusinessNameForm.no).map { _ =>
+                  Redirect(routes.CaptureCompanyNumberController.show(journeyId))
+                }
             }
           )
         }

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/services/StorageService.scala
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/services/StorageService.scala
@@ -37,6 +37,11 @@ class StorageService @Inject()(connector: IncorporatedEntityInformationConnector
                 )(implicit hc: HeaderCarrier): Future[StorageResult] =
     connector.storeData[String](journeyId, StorageService.CtutrKey, ctutr)
 
+  def storeConfirmBusinessName(journeyId: String,
+                               answer: String
+                              )(implicit hc: HeaderCarrier): Future[StorageResult] =
+    connector.storeData[String](journeyId, StorageService.ConfirmBusinessNameKey, answer)
+
   def storeCHRN(journeyId: String,
                 chrn: String
                )(implicit hc: HeaderCarrier): Future[StorageResult] =
@@ -78,6 +83,9 @@ class StorageService @Inject()(connector: IncorporatedEntityInformationConnector
   def retrieveCtutr(journeyId: String)(implicit hc: HeaderCarrier): Future[Option[String]] =
     connector.retrieveIncorporatedEntityInformation[String](journeyId, StorageService.CtutrKey)
 
+  def retrieveConfirmBusinessName(journeyId: String)(implicit hc: HeaderCarrier): Future[Option[String]] =
+    connector.retrieveIncorporatedEntityInformation[String](journeyId, StorageService.ConfirmBusinessNameKey)
+
   def retrieveCHRN(journeyId: String)(implicit hc: HeaderCarrier): Future[Option[String]] =
     connector.retrieveIncorporatedEntityInformation[String](journeyId, StorageService.ChrnKey)
 
@@ -105,6 +113,7 @@ class StorageService @Inject()(connector: IncorporatedEntityInformationConnector
 object StorageService {
   val CompanyProfileKey: String = "companyProfile"
   val CtutrKey: String = "ctutr"
+  val ConfirmBusinessNameKey: String = "confirmBusinessName"
   val ChrnKey: String = "chrn"
   val VerificationStatusKey: String = "businessVerification"
   val RegistrationKey: String = "registration"

--- a/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/confirm_business_name_page.scala.html
+++ b/app/uk/gov/hmrc/incorporatedentityidentificationfrontend/views/confirm_business_name_page.scala.html
@@ -44,8 +44,16 @@
             name = "confirmBusinessName",
             legendAsHeading = false,
             items = Seq(
-                RadioItem(value = Some(yes), content = Text(messages("confirm-business.yes"))),
-                RadioItem(value = Some(no), content = Text(messages("confirm-business.no")))
+                RadioItem(
+                    value = Some(yes),
+                    content = Text(messages("confirm-business.yes")),
+                    checked = form("confirmBusinessName").value.contains(yes)
+                ),
+                RadioItem(
+                    value = Some(no),
+                    content = Text(messages("confirm-business.no")),
+                    checked = form("confirmBusinessName").value.contains(no)
+                )
             ),
             errorMessage = form("confirmBusinessName").error.map(err => err.message),
             inline = true,

--- a/it/test/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/ConfirmBusinessNameControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incorporatedentityidentificationfrontend/controllers/ConfirmBusinessNameControllerISpec.scala
@@ -236,6 +236,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
           authInternalId = testInternalId,
           journeyConfig = testLimitedCompanyJourneyConfig
         ))
+        stubStoreConfirmBusinessName(testJourneyId, "yes")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "yes")
         result must have(
@@ -257,6 +258,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
         val jsonBody = Json.toJsObject(CompanyProfile(testCompanyName, testMismatchCompanyNumber, testDateOfIncorporation, testAddress))
         stubRetrieveCompanyProfileFromBE(testJourneyId)(status = OK, body = jsonBody)
         stubValidateIncorporatedEntityDetails(testMismatchCompanyNumber, Some(testCtutr))(OK, Json.obj("matched" -> false))
+        stubStoreConfirmBusinessName(testJourneyId, "yes")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "yes")
 
@@ -283,6 +285,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
         stubStoreIdentifiersMatch(testJourneyId, identifiersMatch = DetailsMatched)(status = OK)
         stubStoreCtutr(testJourneyId, testCtutr)(status = OK)
         stubStoreBusinessVerificationStatus(testJourneyId, CtEnrolled)(status = OK)
+        stubStoreConfirmBusinessName(testJourneyId, "yes")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "yes")
 
@@ -305,6 +308,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
         stubValidateIncorporatedEntityDetails(testCompanyNumber, Some(testCtutr))(OK, Json.obj("matched" -> true))
         stubStoreIdentifiersMatch(testJourneyId, identifiersMatch = DetailsMatched)(status = OK)
         stubStoreCtutr(testJourneyId, testCtutr)(status = OK)
+        stubStoreConfirmBusinessName(testJourneyId, "yes")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "yes")
 
@@ -323,6 +327,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
           authInternalId = testInternalId,
           journeyConfig = testCharitableIncorporatedOrganisationJourneyConfig
         ))
+        stubStoreConfirmBusinessName(testJourneyId, "yes")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "yes")
 
@@ -341,6 +346,7 @@ class ConfirmBusinessNameControllerISpec extends ComponentSpecHelper
           authInternalId = testInternalId,
           journeyConfig = testLimitedCompanyJourneyConfig
         ))
+        stubStoreConfirmBusinessName(testJourneyId, "no")(status = OK)
 
         lazy val result = post(s"$baseUrl/$testJourneyId/confirm-business-name")("confirmBusinessName" -> "no")
 

--- a/it/test/uk/gov/hmrc/incorporatedentityidentificationfrontend/stubs/IncorporatedEntityIdentificationStub.scala
+++ b/it/test/uk/gov/hmrc/incorporatedentityidentificationfrontend/stubs/IncorporatedEntityIdentificationStub.scala
@@ -58,6 +58,13 @@ trait IncorporatedEntityIdentificationStub extends WireMockMethods {
       status = status
     )
 
+  def stubStoreConfirmBusinessName(journeyId: String, answer: String)(status: Int): StubMapping =
+    when(method = PUT,
+      uri = s"/incorporated-entity-identification/journey/$journeyId/confirmBusinessName", body = JsString(answer)
+    ).thenReturn(
+      status = status
+    )
+
   def stubStoreCHRN(journeyId: String, chrn: String)(status: Int): StubMapping =
     when(method = PUT,
       uri = s"/incorporated-entity-identification/journey/$journeyId/chrn", body = JsString(chrn)

--- a/test/services/StorageServiceSpec.scala
+++ b/test/services/StorageServiceSpec.scala
@@ -77,4 +77,34 @@ class StorageServiceSpec extends UnitSpec with MockIncorporatedEntityInformation
     }
   }
 
+  "retrieveConfirmBusinessName" should {
+    "return Some(answer)" when {
+      "the confirm business name answer exists in the database for a given journey id" in {
+        mockRetrieveIncorporatedEntityInformation[String](
+          testJourneyId,
+          StorageService.ConfirmBusinessNameKey
+        )(Future.successful(Some("yes")))
+
+        val result = await(TestService.retrieveConfirmBusinessName(testJourneyId))
+
+        result mustBe Some("yes")
+        verifyRetrieveIncorporatedEntityInformation[String](testJourneyId, StorageService.ConfirmBusinessNameKey)
+      }
+    }
+
+    "return None" when {
+      "the confirm business name answer does not exist in the database for a given journey id" in {
+        mockRetrieveIncorporatedEntityInformation[String](
+          testJourneyId,
+          StorageService.ConfirmBusinessNameKey
+        )(Future.successful(None))
+
+        val result = await(TestService.retrieveConfirmBusinessName(testJourneyId))
+
+        result mustBe None
+        verifyRetrieveIncorporatedEntityInformation[String](testJourneyId, StorageService.ConfirmBusinessNameKey)
+      }
+    }
+  }
+
 }

--- a/test/views/ConfirmBusinessNamePageViewSpec.scala
+++ b/test/views/ConfirmBusinessNamePageViewSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import _root_.helpers.TestConstants.{testCompanyName, testJourneyId, testLimitedCompanyJourneyConfig}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.incorporatedentityidentificationfrontend.config.AppConfig
+import uk.gov.hmrc.incorporatedentityidentificationfrontend.controllers.routes
+import uk.gov.hmrc.incorporatedentityidentificationfrontend.forms.ConfirmBusinessNameForm
+import uk.gov.hmrc.incorporatedentityidentificationfrontend.views.html.confirm_business_name_page
+
+class ConfirmBusinessNamePageViewSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+
+  private val page = app.injector.instanceOf[confirm_business_name_page]
+  private implicit val messages: Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
+  private implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  private def view(formValue: String): Document =
+    Jsoup.parse(
+      page(
+        pageConfig = testLimitedCompanyJourneyConfig.pageConfig,
+        form = ConfirmBusinessNameForm.form(messages).fill(formValue),
+        formAction = routes.ConfirmBusinessNameController.submit(testJourneyId),
+        companyName = testCompanyName,
+        journeyId = testJourneyId
+      )(FakeRequest(), messages, appConfig).body
+    )
+
+  "ConfirmBusinessNamePageView" should {
+    "preselect yes when the stored answer is yes" in {
+      val document = view(ConfirmBusinessNameForm.yes)
+
+      document.select("input[value=yes]").first().hasAttr("checked") mustBe true
+      document.select("input[value=no]").first().hasAttr("checked") mustBe false
+    }
+
+    "preselect no when the stored answer is no" in {
+      val document = view(ConfirmBusinessNameForm.no)
+
+      document.select("input[value=yes]").first().hasAttr("checked") mustBe false
+      document.select("input[value=no]").first().hasAttr("checked") mustBe true
+    }
+  }
+}


### PR DESCRIPTION
Changes - 

Preserve IEI journey answers when navigating from check your answers

- amended CaptureCompanyNumberController.scala
- amended CaptureCtutrController.scala
- amended ConfirmBusinessNameController.scala
- amended StorageService.scala
- amended confirm_business_name_page.scala.html
- amended StorageServiceSpec.scala
- amended ConfirmBusinessNamePageViewSpec.scala

Related PR's - 

- https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/651
- https://github.com/hmrc/partnership-identification-frontend/pull/116
- https://github.com/hmrc/sole-trader-identification-frontend/pull/257